### PR TITLE
JWT 설정 분리 (만료 시간) / Default 값 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DB_URL=jdbc:mysql://localhost:3306/SpringRider
 DB_USERNAME=your_username
 DB_PASSWORD=your_password
 JWT_KEY=your_jwt_key
+JWT_EXP=3600000

--- a/src/main/java/com/example/springrider/config/jwt/JwtUtil.java
+++ b/src/main/java/com/example/springrider/config/jwt/JwtUtil.java
@@ -21,7 +21,9 @@ import java.util.Date;
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+
+    @Value("${jwt.token.exp}")
+    private long tokenTime;
 
     @Value("${jwt.secret.key}")
     private String secretKey;
@@ -41,7 +43,7 @@ public class JwtUtil {
                 Jwts.builder()
                         .setSubject(String.valueOf(userId))// email로 변화 OK, 바뀔필요성 X
                         .claim("email", email)
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setExpiration(new Date(date.getTime() + tokenTime))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘
                         .compact();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,10 +11,12 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
-
+# JWT
+# 60 min (60 * 60 * 1000ms)
+jwt.token.exp=${JWT_EXP:3600000}
 jwt.secret.key=${JWT_KEY:VEVTVF9ERUZBVUxUX0tFWV9hc2RsanF3ZWxrMSQyaW9jbnhhc2RAIzUzNCM2dSEh}
 
-
+# Logging
 #logging.level.org.springframework.security=DEBUG
 #logging.level.org.springframework.web=DEBUG
 #logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,8 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 
 jwt.secret.key=${JWT_KEY:VEVTVF9ERUZBVUxUX0tFWV9hc2RsanF3ZWxrMSQyaW9jbnhhc2RAIzUzNCM2dSEh}
-
+# 60 min (60 * 60 * 1000ms)
+jwt.token.exp=${JWT_EXP:3600000}
 
 #logging.level.org.springframework.security=DEBUG
 #logging.level.org.springframework.web=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=spring_rider
 # DataSource
-spring.datasource.url=${DB_URL} 
+spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -12,7 +12,9 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 
-jwt.secret.key=${JWT_KEY}
+jwt.secret.key=${JWT_KEY:VEVTVF9ERUZBVUxUX0tFWV9hc2RsanF3ZWxrMSQyaW9jbnhhc2RAIzUzNCM2dSEh}
+
+
 #logging.level.org.springframework.security=DEBUG
 #logging.level.org.springframework.web=DEBUG
 #logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- Refactor/le951/jwt-config -> dev

## 💡 구현 내용 요약
- JWT_KEY Default 값 추가
- JWT exp 값 application.properties로 분리. Default값 추가.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 지켰나요?
- [x] 로직 테스트를 완료했나요?
- [x] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: #5 

## 📝 기타 참고 사항
- exp값은 개발 편의를 위해 (로그인 매번 안해도 되도록) 추가했습니다.
- JWT_KEY의 Default 값도 개발 편의를 위해 추가했습니다.
- JWT_KEY의 Default는 필요성이 높진 않았지만, 생각난 김에 추가했습니다.
